### PR TITLE
Rule update create performance testing polygons load

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,13 +40,17 @@ gem 'activerecord-postgis-adapter'
 # permite ao Rails entender e manipular dados GIS
 gem 'rgeo'
 
+# This gem was made necessary for the configuration of RGeo on startup ('application.rb')
+gem 'ffi-geos'
+
 # extende a capacidade da gema 'rgeo' para lidar com geojson
 gem 'rgeo-geojson'
 
 gem 'data-confirm-modal'
 
 
-group :development, :test do  gem 'pry-byebug'
+group :development, :test do
+  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.13.1)
+    ffi-geos (2.1.0)
+      ffi (>= 1.0.0)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
     globalid (0.4.2)
@@ -252,6 +254,7 @@ DEPENDENCIES
   data-confirm-modal
   devise
   dotenv-rails
+  ffi-geos
   font-awesome-sass
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -45,6 +45,8 @@ class RulesController < ApplicationController
   def create
     @rule = Rule.new(rule_params)
     @polygons = Polygon.find(params[:rule][:polygon_ids])
+    # loading big polygons through RGeo significantly slows down the response (5 - 10 min).
+    # For this reason /config/application.rb has been edited to include a RGeo bypass setting.
     @rule.polygons = @polygons
     @industries = Industry.find(params[:rule][:industry_ids])
     @rule.industries = @industries
@@ -67,6 +69,8 @@ class RulesController < ApplicationController
 
   def update
     if @rule.update(rule_params)
+      # loading big polygons through RGeo significantly slows down the response (5 - 10 min).
+      # For this reason /config/application.rb has been edited to include a RGeo bypass setting.
       @polygons = Polygon.find(params[:rule][:polygon_ids])
       @rule.polygons = @polygons
       @industries = Industry.find(params[:rule][:industry_ids])

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,3 +22,9 @@ module Cella
     # the framework and any gems in your application.
   end
 end
+
+# https://github.com/rgeo/activerecord-postgis-adapter/issues/187#issuecomment-286278821
+RGeo::ActiveRecord::SpatialFactoryStore.instance.tap do |config|
+  # Fetching large MULTIPOLYGON types from the db is very slow without this
+  config.default = RGeo::Geos.factory_generator(uses_lenient_assertions : true)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,5 @@ end
 # https://github.com/rgeo/activerecord-postgis-adapter/issues/187#issuecomment-286278821
 RGeo::ActiveRecord::SpatialFactoryStore.instance.tap do |config|
   # Fetching large MULTIPOLYGON types from the db is very slow without this
-  config.default = RGeo::Geos.factory_generator(uses_lenient_assertions : true)
+  config.default = RGeo::Geos.factory_generator(uses_lenient_assertions:true)
 end


### PR DESCRIPTION
Guys, these changes are meant to reduce the response time when creating and update a rule. Long response times (5 - 10 min) are due to RGeo doing certain checkings when simply loading the corresponding polygons. Response times for creating and updating should be within 5 seconds to a minute depending on the polygon size. I know it is still slow, but this is a great improvement anyway.